### PR TITLE
Feature/paginated asset path list

### DIFF
--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
@@ -331,93 +331,38 @@ class ImageScanner(private val registrar: PluginRegistry.Registrar) {
             val pageSize = (call.arguments as Map<String, Any>)["pageSize"] as Int
             val pathId = (call.arguments as Map<String, Any>)["id"] as String?
 
-            val mImageUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-            val mVideoUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-            val mContentResolver = registrar.activity().contentResolver
-            val imageCursor = mContentResolver.query(mImageUri, storeImageKeys, if (pathId == null) null else "${MediaStore.Images.ImageColumns.BUCKET_ID} = $pathId", null, MediaStore.Images.Media.DATE_TAKEN)
-            if (imageCursor!!.count > 0) {
-                imageCursor.moveToLast()
-            } else {
-                imageCursor.close()
-            }
-            val videoCursor = mContentResolver.query(mVideoUri, storeVideoKeys, if (pathId == null) null else "${MediaStore.Video.VideoColumns.BUCKET_ID} = $pathId", null, MediaStore.Video.Media.DATE_TAKEN)
-            if (videoCursor!!.count > 0) {
-                videoCursor.moveToLast()
-            } else {
-                videoCursor.close()
-            }
+            val cursor = registrar.activity().contentResolver.query(
+                    MediaStore.Files.getContentUri("external"),
+                    (storeImageKeys + storeVideoKeys + arrayOf(MediaStore.Files.FileColumns.MEDIA_TYPE)).distinct().toTypedArray(),
+                    if (pathId == null) "" else " ${MediaStore.Images.ImageColumns.BUCKET_ID} = $pathId AND " +
+                            "${MediaStore.Files.FileColumns.MEDIA_TYPE} in (${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE}, ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO})",
+                    null,
+                    "${MediaStore.Images.Media.DATE_TAKEN} DESC"
+            )
             val list = mutableListOf<String>()
-            var current: Long = 0
-            while (list.size < pageSize) {
-                var imageDate: Long = -1
-                var videoDate: Long = -1
-                if (!imageCursor.isClosed) {
-                    imageDate = imageCursor.getLong(imageCursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN))
-                }
-                if (!videoCursor.isClosed) {
-                    videoDate = videoCursor.getLong(videoCursor.getColumnIndex(MediaStore.Video.Media.DATE_TAKEN))
-                }
-                if (imageDate == -1L && videoDate == -1L) {
-                    break
-                }
-                if (imageDate >= videoDate) {
-                    if (current >= page * pageSize) {
-                        val path = imageCursor.getString(imageCursor
-                                .getColumnIndex(MediaStore.Images.Media.DATA))
-                        val dir = imageCursor.getString(imageCursor.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME))
-                        val dirId = imageCursor.getString(imageCursor.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_ID))
-                        val title = imageCursor.getString(imageCursor.getColumnIndex(MediaStore.Images.ImageColumns.TITLE))
-                        val thumb = imageCursor.getString(imageCursor.getColumnIndex(MediaStore.Images.ImageColumns.MINI_THUMB_MAGIC))
-                        val imgId = imageCursor.getString(imageCursor.getColumnIndex(MediaStore.Images.ImageColumns._ID))
-                        val date = imageCursor.getLong(imageCursor.getColumnIndex(MediaStore.Images.ImageColumns.DATE_TAKEN))
-                        val width = imageCursor.getInt(imageCursor.getColumnIndex(MediaStore.Images.Media.WIDTH))
-                        val height = imageCursor.getInt(imageCursor.getColumnIndex(MediaStore.Images.Media.HEIGHT))
-
-                        if (width > 0 && height > 0) {
-                            val img = Asset(path, imgId, dir, dirId, title, thumb, AssetType.Image, date, null, width, height)
-
-                            val file = File(path)
-                            if (file.exists()) {
-                                pathAssetMap[path] = img
-                                list.add(img.path)
-                            }
-                        }
+            if (cursor != null && cursor.moveToPosition(page * pageSize)) {
+                while (list.size < pageSize && cursor.moveToNext()) {
+                    val mediaType = cursor.getInt(cursor.getColumnIndex(MediaStore.Files.FileColumns.MEDIA_TYPE))
+                    val path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA))
+                    val dir = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME))
+                    val dirId = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_ID))
+                    val title = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.TITLE))
+                    val thumb = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.MINI_THUMB_MAGIC))
+                    val imgId = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns._ID))
+                    val date = cursor.getLong(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DATE_TAKEN))
+                    val width = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.WIDTH))
+                    val height = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.HEIGHT))
+                    val durationMs = if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+                        cursor.getLong(cursor.getColumnIndex(MediaStore.Video.Media.DURATION))
+                    } else {
+                        null
                     }
-
-                    if (!imageCursor.moveToPrevious()) {
-                        imageCursor.close()
-                    }
-                } else {
-                    if (current >= page * pageSize) {
-                        val path = videoCursor.getString(videoCursor
-                                .getColumnIndex(MediaStore.Video.Media.DATA))
-                        val dir = videoCursor.getString(videoCursor.getColumnIndex(MediaStore.Video.Media.BUCKET_DISPLAY_NAME))
-                        val dirId = videoCursor.getString(videoCursor.getColumnIndex(MediaStore.Video.Media.BUCKET_ID))
-                        val title = videoCursor.getString(videoCursor.getColumnIndex(MediaStore.Video.Media.TITLE))
-                        val thumb = videoCursor.getString(videoCursor.getColumnIndex(MediaStore.Video.Media.MINI_THUMB_MAGIC))
-                        val imgId = videoCursor.getString(videoCursor.getColumnIndex(MediaStore.Video.Media._ID))
-                        val date = videoCursor.getLong(videoCursor.getColumnIndex(MediaStore.Video.Media.DATE_TAKEN))
-                        val durationMs = videoCursor.getLong(videoCursor.getColumnIndex(MediaStore.Video.Media.DURATION))
-
-                        val width = videoCursor.getInt(videoCursor.getColumnIndex(MediaStore.Video.Media.WIDTH))
-                        val height = videoCursor.getInt(videoCursor.getColumnIndex(MediaStore.Video.Media.HEIGHT))
-
-                        val img = Asset(path, imgId, dir, dirId, title, thumb, AssetType.Video, date, durationMs, width, height)
-
-                        if (width > 0 && height > 0) {
-                            val file = File(path)
-                            if (file.exists()) {
-                                pathAssetMap[path] = img
-                                list.add(img.path)
-                            }
-                        }
-                    }
-                    if (!videoCursor.moveToPrevious()) {
-                        videoCursor.close()
-                    }
+                    val img = Asset(path, imgId, dir, dirId, title, thumb, AssetType.Video, date, durationMs, width, height)
+                    pathAssetMap[path] = img
+                    list.add(path)
                 }
-                ++current;
             }
+            cursor?.close()
             resultHandler.reply(list)
         }
     }

--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
@@ -611,7 +611,8 @@ class ImageScanner(private val registrar: PluginRegistry.Registrar) {
                 } else {
                     null
                 }
-                img = Asset(path, imgId, dir, dirId, title, thumb, AssetType.Video, date, durationMs, width, height)
+                val type = if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) AssetType.Video else AssetType.Image
+                img = Asset(path, imgId, dir, dirId, title, thumb, type, date, durationMs, width, height)
             }
             cursor?.close()
         }

--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
@@ -330,12 +330,15 @@ class ImageScanner(private val registrar: PluginRegistry.Registrar) {
             val page = (call.arguments as Map<String, Any>)["page"] as Int
             val pageSize = (call.arguments as Map<String, Any>)["pageSize"] as Int
             val pathId = (call.arguments as Map<String, Any>)["id"] as String?
+            val hasVideo = (call.arguments as Map<String, Any>)["hasVideo"] as Boolean
 
             val cursor = registrar.activity().contentResolver.query(
                     MediaStore.Files.getContentUri("external"),
                     (storeImageKeys + storeVideoKeys + arrayOf(MediaStore.Files.FileColumns.MEDIA_TYPE)).distinct().toTypedArray(),
                     if (pathId == null) "" else " ${MediaStore.Images.ImageColumns.BUCKET_ID} = $pathId AND " +
-                            "${MediaStore.Files.FileColumns.MEDIA_TYPE} in (${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE}, ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO})",
+                            "${MediaStore.Files.FileColumns.MEDIA_TYPE} in (${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE}" +
+                            (if (hasVideo) ", ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO}" else "") +
+                            ")",
                     null,
                     "${MediaStore.Images.Media.DATE_TAKEN} DESC"
             )

--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
@@ -342,23 +342,7 @@ class ImageScanner(private val registrar: PluginRegistry.Registrar) {
             val list = mutableListOf<String>()
             if (cursor != null && cursor.moveToPosition(page * pageSize)) {
                 while (list.size < pageSize && cursor.moveToNext()) {
-                    val mediaType = cursor.getInt(cursor.getColumnIndex(MediaStore.Files.FileColumns.MEDIA_TYPE))
                     val path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA))
-                    val dir = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME))
-                    val dirId = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.BUCKET_ID))
-                    val title = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.TITLE))
-                    val thumb = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.MINI_THUMB_MAGIC))
-                    val imgId = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns._ID))
-                    val date = cursor.getLong(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DATE_TAKEN))
-                    val width = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.WIDTH))
-                    val height = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.HEIGHT))
-                    val durationMs = if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
-                        cursor.getLong(cursor.getColumnIndex(MediaStore.Video.Media.DURATION))
-                    } else {
-                        null
-                    }
-                    val img = Asset(path, imgId, dir, dirId, title, thumb, AssetType.Video, date, durationMs, width, height)
-                    pathAssetMap[path] = img
                     list.add(path)
                 }
             }

--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScanner.kt
@@ -334,13 +334,13 @@ class ImageScanner(private val registrar: PluginRegistry.Registrar) {
             val mImageUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
             val mVideoUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
             val mContentResolver = registrar.activity().contentResolver
-            val imageCursor = mContentResolver.query(mImageUri, storeImageKeys, "${MediaStore.Images.ImageColumns.BUCKET_ID} = $pathId", null, MediaStore.Images.Media.DATE_TAKEN)
+            val imageCursor = mContentResolver.query(mImageUri, storeImageKeys, if (pathId == null) null else "${MediaStore.Images.ImageColumns.BUCKET_ID} = $pathId", null, MediaStore.Images.Media.DATE_TAKEN)
             if (imageCursor!!.count > 0) {
                 imageCursor.moveToLast()
             } else {
                 imageCursor.close()
             }
-            val videoCursor = mContentResolver.query(mVideoUri, storeBucketKeys, "${MediaStore.Video.VideoColumns.BUCKET_ID} = $pathId", null, MediaStore.Video.Media.DATE_TAKEN)
+            val videoCursor = mContentResolver.query(mVideoUri, storeVideoKeys, if (pathId == null) null else "${MediaStore.Video.VideoColumns.BUCKET_ID} = $pathId", null, MediaStore.Video.Media.DATE_TAKEN)
             if (videoCursor!!.count > 0) {
                 videoCursor.moveToLast()
             } else {

--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScannerPlugin.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScannerPlugin.kt
@@ -57,6 +57,10 @@ class ImageScannerPlugin(val registrar: Registrar) : MethodCallHandler {
                 scanner.getImageListWithPathId(call, result)
                 true
             }
+            call.method == "getImageListPaged" -> {
+                scanner.getImageListPaged(call, result)
+                true
+            }
             call.method == "getAllImageList" -> {
                 scanner.getAllImageList(call, result)
                 true

--- a/ios/Classes/ImageScanner.h
+++ b/ios/Classes/ImageScanner.h
@@ -24,6 +24,8 @@ typedef void (^asset_block)(PHCollection *collection, PHAsset *asset);
 
 - (void)getImageListWithCall:(FlutterMethodCall *)call result:(FlutterResult)flutterResult;
 
+- (void)getImageListPaged:(FlutterMethodCall *)call result:(FlutterResult)flutterResult;
+
 - (void)filterAssetWithBlock:(asset_block)block;
 
 - (void)forEachAssetCollection:(FlutterMethodCall *)call result:(FlutterResult)flutterResult;

--- a/ios/Classes/ImageScanner.m
+++ b/ios/Classes/ImageScanner.m
@@ -191,10 +191,10 @@
 
         opt.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
         NSUInteger count = 0;
+        NSUInteger lowerBoundary = page * pageSize;
         for (PHAssetCollection *assetCollection in r) {
             PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection
                                                                                   options:opt];
-            NSUInteger lowerBoundary = page * pageSize;
             for (NSUInteger idx = lowerBoundary; idx < fetchResult.count && count < pageSize; ++idx) {
                 PHAsset *asset = fetchResult[idx];
                 if (!asset.isVideo || (asset.isVideo && hasVideo)) {
@@ -205,6 +205,7 @@
                 }
             }
             if (count >= pageSize) break;
+            lowerBoundary = MAX(lowerBoundary - fetchResult.count, 0);
         }
 
         flutterResult(arr);

--- a/ios/Classes/ImageScanner.m
+++ b/ios/Classes/ImageScanner.m
@@ -189,6 +189,7 @@
 
         NSMutableArray<NSString *> *arr = [NSMutableArray new];
 
+        opt.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
         NSUInteger count = 0;
         for (PHAssetCollection *assetCollection in r) {
             PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection

--- a/ios/Classes/ImageScannerPlugin.m
+++ b/ios/Classes/ImageScannerPlugin.m
@@ -37,6 +37,8 @@
         [_scanner getGalleryNameWithCall:call result:result];
     } else if ([@"getImageListWithPathId" isEqualToString:call.method]) {
         [_scanner getImageListWithCall:call result:result];
+    } else if ([@"getImageListPaged" isEqualToString:call.method]) {
+        [_scanner getImageListPaged:call result:result];
     } else if ([@"getAllImageList" isEqualToString:call.method]) {
         [_scanner forEachAssetCollection:call result:result];
     } else if ([@"getThumbPath" isEqualToString:call.method]) {

--- a/lib/src/entity.dart
+++ b/lib/src/entity.dart
@@ -41,6 +41,12 @@ class AssetPathEntity {
   /// the image entity list
   Future<List<AssetEntity>> get assetList => PhotoManager._getAssetList(this);
 
+  /// the image  entity list with pagination
+  ///
+  /// Doesn't support AssetPathEntity with only(Video/Image) flag.
+  /// Throws UnsupportedError
+  Future<List<AssetEntity>> getAssetListPaged(int page, int pageSize) => PhotoManager._getAssetListPaged(this, page, pageSize);
+
   static var _all = AssetPathEntity()
     ..id = "allall--dfnsfkdfj2454AJJnfdkl"
     ..name = "Recent"

--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -186,6 +186,28 @@ class PhotoManager {
     return _filterType(entityList, path.hasVideo == true);
   }
 
+  /// get image entity with path with pagination
+  ///
+  /// Doesn't support AssetPathEntity with only(Video/Image) flag.
+  /// Throws UnsupportedError
+  static Future<List<AssetEntity>> _getAssetListPaged(
+      AssetPathEntity path, int page, int pageSize) async {
+    if (path.onlyImage || path.onlyVideo) throw UnsupportedError("Doesn't support AssetPathEntity with only(Video/Image) flag");
+    List<dynamic> list;
+    final Map<String, dynamic> args = {
+      "page": page,
+      "pageSize": pageSize,
+      "hasVideo": path.hasVideo,
+    };
+    if (path.isAll == false) {
+      args["id"] = path.id;
+    }
+    list = await _channel.invokeMethod("getImageListPaged", args);
+    var entityList = list.map((v) => AssetEntity(id: v.toString())).toList();
+    await _fetchTypeAndTime(entityList);
+    return entityList;
+  }
+
   static Future<List<AssetEntity>> _castAsset(
       List<dynamic> ids, AssetType type) async {
     var timeStampList = await _getTimeStampWithIds(ids.cast());


### PR DESCRIPTION
Partly implemented feature mentioned in this issue #91


Original issue proposed paginated version of `getAssetPathList`. But I noticed, that real fetch is happening in `_getAssetList`. Therefore, I implemented a `_getAssetListPaged`.


It's only works for AssetPathEntity with (onlyImage || onlyVideo == false). This behavior is caused by the current implementation of getVideoPathList and getImagePathList: on ios it fetches and filters out collections if they doesn't contain assets of corresponding type. I didn't find a way to filter them fast, so pagination wouldn't solve the performance problem for this type of assets.


On android side I changed `scanAndGetImageIdList` implementation a bit:
- `scan()` => `scanBuckets()`
- and added deferred call to `scan()` in `getImageListWithPathId` and `getAllImageList`

Then i changed `getImageWithId` implementation, now it fetches Asset if it's not in the cache.



These changes were made at the request of the creator of the #91 issue and are used by him in his project.

If something is unclear or does not match your vision of this feature, I'm ready to discuss.