### PR TITLE
Fix null duration

### DIFF
--- a/lib/src/entity.dart
+++ b/lib/src/entity.dart
@@ -154,7 +154,7 @@ class AssetEntity {
   }
 
   /// if not video ,duration is null
-  Duration get videoDuration => Duration(seconds: duration);
+  Duration get videoDuration => Duration(seconds: duration ?? 0);
 
   /// nullable, if the manager is null.
   Size get size => Size(width.toDouble(), height.toDouble());


### PR DESCRIPTION
It avoids the error: The method '_mulFromInteger' was called on null.

Here I explain my case: https://github.com/CaiJingLong/flutter_photo/issues/66