### PR TITLE
Fix for album iteration when a folder exists in the user gallery

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -71,7 +71,7 @@
                           hasAll:(BOOL)hasAll {
     for (id collection in result) {
         if (![collection isMemberOfClass:[PHAssetCollection class]]) {
-            return;
+            continue;
         }
 
         PHAssetCollection *assetCollection = (PHAssetCollection *) collection;


### PR DESCRIPTION
Don't break the iteration when a non-supported type appears.