### PR TITLE
Remove undesired verbose log

### DIFF
--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -266,8 +266,6 @@ class PhotoManager {
 
     final asset = ConvertUtils.convertToAsset(map);
 
-    print(asset);
-
     if (asset == null) {
       return null;
     }


### PR DESCRIPTION
While displaying a gallery with a large list of photos, this line floods the logs. Kindly remove if unnecessary. Thanks.