### PR TITLE
Make use of permission_handler instead of our own implementation

### DIFF
--- a/lib/photo_manager.dart
+++ b/lib/photo_manager.dart
@@ -6,6 +6,7 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/src/utils/convert_utils.dart';
 import 'src/filter/filter_options.dart';
 

--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -10,7 +10,14 @@ class PhotoManager {
   ///
   /// in ios request the photo permission
   static Future<bool> requestPermission() async {
-    return _plugin.requestPermission();
+    if(Platform.isAndroid){
+      return (await Permission.storage.request()) == PermissionStatus.granted;
+    } else if(Platform.isIOS) {
+      // WARNING - THIS IS NOT TESTED!
+      return (await Permission.photos.request()) == PermissionStatus.granted;
+    } else return false;
+    // TODO: Delete old permission handling
+    //  in Android and iOS parts of the plugin
   }
 
   static Editor editor = Editor();

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photo_manager/src/utils/convert_utils.dart';
 
@@ -41,7 +42,15 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
   }
 
   Future<bool> requestPermission() async {
-    return (await _channel.invokeMethod("requestPermission")) == 1;
+    if (Platform.isAndroid) {
+      return (await Permission.storage.request()) == PermissionStatus.granted;
+    } else if (Platform.isIOS) {
+      // WARNING - THIS IS NOT TESTED!
+      return (await Permission.photos.request()) == PermissionStatus.granted;
+    } else
+      return false;
+    // TODO: Delete old permission handling
+    //  in Android and iOS parts of the plugin
   }
 
   Future<List<AssetEntity>> getAssetWithGalleryIdPaged(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  permission_handler: ^5.0.1+1
+
 flutter:
   plugin:
     platforms:


### PR DESCRIPTION
This PR adds [permission_handler](https://pub.dev/packages/permission_handler) as a dependency, and makes use of it. Thanks to this, we will have easier job of messing with permissions, and we can check permissions without Activity (see discussion in #287 )

Changes made by me still need to be tested on iOS, and on new Android 11 !

If @CaiJingLong will decide to accept this, it will also be nice to remove old attempts in Android and iOS sides.