### PR TITLE
#385-ios14-limited-permission-support

### DIFF
--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -13,6 +13,10 @@ class PhotoManager {
     return _plugin.requestPermission();
   }
 
+  /// Provide more information about the actual permission being granted.
+  /// This can account for the .limited permission in iOS 14.
+  static Future<PhotoPermission> requestPermissionExtended() async => _plugin.requestPermissionExtended();
+
   static Editor editor = Editor();
 
   /// get gallery list
@@ -37,8 +41,7 @@ class PhotoManager {
     }
     filterOption ??= FilterOptionGroup();
 
-    assert(
-        type.index != 0, 'The request type must have video, image or audio.');
+    assert(type.index != 0, 'The request type must have video, image or audio.');
 
     if (type.index == 0) {
       return [];
@@ -148,12 +151,10 @@ class PhotoManager {
   static _NotifyManager _notifyManager = _NotifyManager();
 
   /// see [_NotifyManager]
-  static void addChangeCallback(ValueChanged<MethodCall> callback) =>
-      _notifyManager.addCallback(callback);
+  static void addChangeCallback(ValueChanged<MethodCall> callback) => _notifyManager.addCallback(callback);
 
   /// see [_NotifyManager]
-  static void removeChangeCallback(ValueChanged<MethodCall> callback) =>
-      _notifyManager.removeCallback(callback);
+  static void removeChangeCallback(ValueChanged<MethodCall> callback) => _notifyManager.removeCallback(callback);
 
   /// see [_NotifyManager]
   static void startChangeNotify() => _notifyManager.startHandleNotify();
@@ -239,8 +240,7 @@ class PhotoManager {
   }
 
   /// When set to true, originbytes in Android Q will be cached as a file. When use again, the file will be read.
-  static Future<bool> setCacheAtOriginBytes(bool cache) =>
-      _plugin.cacheOriginBytes(cache);
+  static Future<bool> setCacheAtOriginBytes(bool cache) => _plugin.cacheOriginBytes(cache);
 
   static Future<Uint8List> _getOriginBytes(AssetEntity assetEntity) async {
     assert(Platform.isAndroid || Platform.isIOS || Platform.isMacOS);
@@ -262,8 +262,7 @@ class PhotoManager {
     return _plugin.getMediaUrl(assetEntity);
   }
 
-  static Future<List<AssetPathEntity>> _getSubPath(
-      AssetPathEntity assetPathEntity) {
+  static Future<List<AssetPathEntity>> _getSubPath(AssetPathEntity assetPathEntity) {
     assert(Platform.isIOS || Platform.isMacOS);
     return _plugin.getSubPathEntities(assetPathEntity);
   }
@@ -271,8 +270,7 @@ class PhotoManager {
   /// Refresh the property of asset.
   static Future<AssetEntity> refreshAssetProperties(AssetEntity src) async {
     assert(src.id != null);
-    final Map<dynamic, dynamic> map =
-        await _plugin.getPropertiesFromAssetEntity(src.id);
+    final Map<dynamic, dynamic> map = await _plugin.getPropertiesFromAssetEntity(src.id);
 
     final asset = ConvertUtils.convertToAsset(map);
 

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -44,7 +44,13 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
 
   /// request permission.
   Future<bool> requestPermission() async {
-    return (await _channel.invokeMethod("requestPermission")) == 1;
+    final permission = await requestPermissionExtended();
+    return permission == PhotoPermission.full || permission == PhotoPermission.limited;
+  }
+
+  Future<PhotoPermission> requestPermissionExtended() async {
+    final permission = await _channel.invokeMethod("requestPermission");
+    return PhotoPermission.values[permission];
   }
 
   /// Use pagination to get album content.
@@ -119,8 +125,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     _channel.invokeMethod("openSetting");
   }
 
-  Future<Map> fetchPathProperties(
-      String id, int type, FilterOptionGroup optionGroup) async {
+  Future<Map> fetchPathProperties(String id, int type, FilterOptionGroup optionGroup) async {
     return _channel.invokeMethod(
       "fetchPathProperties",
       {
@@ -148,13 +153,11 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
   }
 
   Future<List<String>> deleteWithIds(List<String> ids) async {
-    final List<dynamic> deleted =
-        (await _channel.invokeMethod("deleteWithIds", {"ids": ids}));
+    final List<dynamic> deleted = (await _channel.invokeMethod("deleteWithIds", {"ids": ids}));
     return deleted.cast<String>();
   }
 
-  Future<AssetEntity> saveImage(Uint8List uint8list,
-      {String title, String desc = ""}) async {
+  Future<AssetEntity> saveImage(Uint8List uint8list, {String title, String desc = ""}) async {
     title ??= "image_${DateTime.now().millisecondsSinceEpoch / 1000}";
 
     final result = await _channel.invokeMethod(
@@ -169,8 +172,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     return ConvertUtils.convertToAsset(result);
   }
 
-  Future<AssetEntity> saveImageWithPath(String path,
-      {String title, String desc = ""}) async {
+  Future<AssetEntity> saveImageWithPath(String path, {String title, String desc = ""}) async {
     final file = File(path);
     if (!file.existsSync()) {
       assert(file.existsSync(), "file must exists");
@@ -223,8 +225,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     if (Platform.isAndroid) {
       final version = int.parse(await getSystemVersion());
       if (version >= 29) {
-        final map = await _channel
-            .invokeMethod("getLatLngAndroidQ", {"id": assetEntity.id});
+        final map = await _channel.invokeMethod("getLatLngAndroidQ", {"id": assetEntity.id});
         if (map is Map) {
           /// 将返回的数据传入map
           return LatLng()
@@ -262,8 +263,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     });
   }
 
-  Future<List<AssetPathEntity>> getSubPathEntities(
-      AssetPathEntity pathEntity) async {
+  Future<List<AssetPathEntity>> getSubPathEntities(AssetPathEntity pathEntity) async {
     final result = await _channel.invokeMethod("getSubPath", {
       "id": pathEntity.id,
       "type": pathEntity.type.value,
@@ -280,11 +280,9 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     );
   }
 
-  Future<AssetEntity> copyAssetToGallery(
-      AssetEntity asset, AssetPathEntity pathEntity) async {
+  Future<AssetEntity> copyAssetToGallery(AssetEntity asset, AssetPathEntity pathEntity) async {
     if (pathEntity.isAll) {
-      assert(pathEntity.isAll,
-          "You don't need to copy the asset into the album containing all the pictures.");
+      assert(pathEntity.isAll, "You don't need to copy the asset into the album containing all the pictures.");
       return null;
     }
 
@@ -339,8 +337,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     await _channel.invokeMethod('cancelCacheRequests');
   }
 
-  Future<void> requestCacheAssetsThumb(
-      List<String> ids, ThumbOption option) async {
+  Future<void> requestCacheAssetsThumb(List<String> ids, ThumbOption option) async {
     assert(ids != null);
     assert(ids.isNotEmpty);
     assert(option != null);
@@ -356,8 +353,7 @@ mixin BasePlugin {
 }
 
 mixin IosPlugin on BasePlugin {
-  Future<AssetPathEntity> iosCreateFolder(
-      String name, bool isRoot, AssetPathEntity parent) async {
+  Future<AssetPathEntity> iosCreateFolder(String name, bool isRoot, AssetPathEntity parent) async {
     final map = {
       "name": name,
       "isRoot": isRoot,
@@ -386,8 +382,7 @@ mixin IosPlugin on BasePlugin {
       ..albumType = 2;
   }
 
-  Future<AssetPathEntity> iosCreateAlbum(
-      String name, bool isRoot, AssetPathEntity parent) async {
+  Future<AssetPathEntity> iosCreateAlbum(String name, bool isRoot, AssetPathEntity parent) async {
     final map = {
       "name": name,
       "isRoot": isRoot,
@@ -416,8 +411,7 @@ mixin IosPlugin on BasePlugin {
       ..albumType = 1;
   }
 
-  Future<bool> iosRemoveInAlbum(
-      List<AssetEntity> entities, AssetPathEntity path) async {
+  Future<bool> iosRemoveInAlbum(List<AssetEntity> entities, AssetPathEntity path) async {
     final result = await _channel.invokeMethod(
       "removeInAlbum",
       {
@@ -436,8 +430,7 @@ mixin IosPlugin on BasePlugin {
 }
 
 mixin AndroidPlugin on BasePlugin {
-  Future<bool> androidMoveAssetToPath(
-      AssetEntity entity, AssetPathEntity target) async {
+  Future<bool> androidMoveAssetToPath(AssetEntity entity, AssetPathEntity target) async {
     final result = await _channel.invokeMethod("moveAssetToPath", {
       "assetId": entity.id,
       "albumId": target.id,

--- a/lib/src/type.dart
+++ b/lib/src/type.dart
@@ -91,3 +91,11 @@ enum ResizeMode { none, fast, exact }
 
 /// Resize content mode
 enum ResizeContentMode { fit, fill, def }
+
+/// Represent possible permission states,
+enum PhotoPermission {
+  none,
+  full,
+  // only applicable to iOS 14+
+  limited,
+}


### PR DESCRIPTION
+ Add an enum to represent the different permission states
+ Add a new method to request permissions that returns an instance
  of this enum instead of only `true` or `false`
+ Change MethodChannel implementation in the iOS plugin to
  1. Check for iOS 14
  2. Use new `requestAuthorizationForAccessLevel` API
  3. Differentiate between full access and limited access if applicable.
  The implementation for pre-iOS14 stays unchanged.