### PR TITLE
Add refreshing relative path in Asset.refreshProperties()

### DIFF
--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -290,7 +290,8 @@ class PhotoManager {
       ..typeInt = asset.typeInt
       ..longitude = asset.longitude
       ..latitude = asset.latitude
-      ..title = asset.title;
+      ..title = asset.title
+      ..relativePath = asset.relativePath;
 
     return src;
   }


### PR DESCRIPTION
I noticed that my Assets lack `relativePath` (added in #272) when I create them by id and then call `.refreshProperties()`

It looks like `.refreshProperties()` lacks some other properties, like `.orientation`

But as I see, `refreshAssetProperties` (at line 272 in `lib/src/manager.dart` literally copies every property manually. Can't we just.. copy whole object and return it instead?