### PR TITLE
Allow specifying a RELATIVE_PATH when saving a file to the MediaStore…

### DIFF
--- a/android/src/main/kotlin/top/kikt/imagescanner/core/PhotoManager.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/PhotoManager.kt
@@ -164,19 +164,19 @@ class PhotoManager(private val context: Context) {
     resultHandler.reply(path)
   }
 
-  fun saveImage(image: ByteArray, title: String, description: String): AssetEntity? {
-    return dbUtils.saveImage(context, image, title, description)
+  fun saveImage(image: ByteArray, title: String, description: String, relativePath: String): AssetEntity? {
+    return dbUtils.saveImage(context, image, title, description, relativePath)
   }
 
-  fun saveImage(path: String, title: String, description: String): AssetEntity? {
-    return dbUtils.saveImage(context, path, title, description)
+  fun saveImage(path: String, title: String, description: String, relativePath: String): AssetEntity? {
+    return dbUtils.saveImage(context, path, title, description, relativePath)
   }
 
-  fun saveVideo(path: String, title: String, desc: String): AssetEntity? {
+  fun saveVideo(path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     if (!File(path).exists()) {
       return null
     }
-    return dbUtils.saveVideo(context, path, title, desc)
+    return dbUtils.saveVideo(context, path, title, desc, relativePath)
   }
 
   fun assetExists(id: String, resultHandler: ResultHandler) {

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/PhotoManagerPlugin.kt
@@ -359,7 +359,8 @@ class PhotoManagerPlugin(
             val image = call.argument<ByteArray>("image")!!
             val title = call.argument<String>("title") ?: ""
             val desc = call.argument<String>("desc") ?: ""
-            val entity = photoManager.saveImage(image, title, desc)
+            val relativePath = call.argument<String>("relativePath") ?: ""
+            val entity = photoManager.saveImage(image, title, desc, relativePath)
             if (entity == null) {
               resultHandler.reply(null)
               return@runOnBackground
@@ -378,7 +379,8 @@ class PhotoManagerPlugin(
             val imagePath = call.argument<String>("path")!!
             val title = call.argument<String>("title") ?: ""
             val desc = call.argument<String>("desc") ?: ""
-            val entity = photoManager.saveImage(imagePath, title, desc)
+            val relativePath = call.argument<String>("relativePath") ?: ""
+            val entity = photoManager.saveImage(imagePath, title, desc, relativePath)
             if (entity == null) {
               resultHandler.reply(null)
               return@runOnBackground
@@ -397,7 +399,8 @@ class PhotoManagerPlugin(
             val videoPath = call.argument<String>("path")!!
             val title = call.argument<String>("title")!!
             val desc = call.argument<String>("desc") ?: ""
-            val entity = photoManager.saveVideo(videoPath, title, desc)
+            val relativePath = call.argument<String>("relativePath") ?: ""
+            val entity = photoManager.saveVideo(videoPath, title, desc, relativePath)
             if (entity == null) {
               resultHandler.reply(null)
               return@runOnBackground

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/Android30DbUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/Android30DbUtils.kt
@@ -382,7 +382,7 @@ object Android30DbUtils : IDBUtils {
       typeFromStream = "image/${File(title).extension}"
     } else {
       typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
-              ?: "image/${File(title).extension}"
+              ?: "image/*"
     }
 
     val uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/Android30DbUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/Android30DbUtils.kt
@@ -362,7 +362,7 @@ object Android30DbUtils : IDBUtils {
     androidQCache.saveAssetCache(context, asset, byteArray, true)
   }
 
-  override fun saveImage(context: Context, image: ByteArray, title: String, desc: String): AssetEntity? {
+  override fun saveImage(context: Context, image: ByteArray, title: String, desc: String, relativePath: String): AssetEntity? {
     val (width, height) =
         try {
           val bmp = BitmapFactory.decodeByteArray(image, 0, image.count())
@@ -393,6 +393,7 @@ object Android30DbUtils : IDBUtils {
       put(MediaStore.Images.ImageColumns.WIDTH, width)
       put(MediaStore.Images.ImageColumns.HEIGHT, height)
     }
+    if (relativePath != null) values.put(MediaStore.Images.ImageColumns.RELATIVE_PATH, relativePath)
 
     val contentUri = cr.insert(uri, values) ?: return null
     val outputStream = cr.openOutputStream(contentUri)
@@ -409,7 +410,7 @@ object Android30DbUtils : IDBUtils {
     return getAssetEntity(context, id.toString())
   }
 
-  override fun saveImage(context: Context, path: String, title: String, desc: String): AssetEntity? {
+  override fun saveImage(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
     val inputStream = FileInputStream(path)
@@ -441,6 +442,7 @@ object Android30DbUtils : IDBUtils {
       put(MediaStore.Images.ImageColumns.WIDTH, width)
       put(MediaStore.Images.ImageColumns.HEIGHT, height)
     }
+    if (relativePath != null) values.put(MediaStore.Images.ImageColumns.RELATIVE_PATH, relativePath)
 
     val contentUri = cr.insert(uri, values) ?: return null
     val outputStream = cr.openOutputStream(contentUri)
@@ -638,7 +640,7 @@ object Android30DbUtils : IDBUtils {
     }
   }
 
-  override fun saveVideo(context: Context, path: String, title: String, desc: String): AssetEntity? {
+  override fun saveVideo(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
     val inputStream = FileInputStream(path)
@@ -664,6 +666,7 @@ object Android30DbUtils : IDBUtils {
       put(MediaStore.Video.VideoColumns.WIDTH, info.width)
       put(MediaStore.Video.VideoColumns.HEIGHT, info.height)
     }
+    if (relativePath != null) values.put(MediaStore.Video.VideoColumns.RELATIVE_PATH, relativePath)
 
     val contentUri = cr.insert(uri, values) ?: return null
     val outputStream = cr.openOutputStream(contentUri)

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/Android30DbUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/Android30DbUtils.kt
@@ -376,7 +376,14 @@ object Android30DbUtils : IDBUtils {
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
 
-    val typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
+    var typeFromStream: String;
+    if (title.contains(".")){
+      //title contains file extension, form mimeType from it
+      typeFromStream = "image/${File(title).extension}"
+    } else {
+      typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
+              ?: "image/${File(title).extension}"
+    }
 
     val uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
 

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/AndroidQDBUtils.kt
@@ -377,7 +377,7 @@ object AndroidQDBUtils : IDBUtils {
       typeFromStream = "image/${File(title).extension}"
     } else {
       typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
-              ?: "image/${File(title).extension}"
+              ?: "image/*"
     }
 
     val uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/AndroidQDBUtils.kt
@@ -357,7 +357,7 @@ object AndroidQDBUtils : IDBUtils {
     androidQCache.saveAssetCache(context, asset, byteArray, true)
   }
 
-  override fun saveImage(context: Context, image: ByteArray, title: String, desc: String): AssetEntity? {
+  override fun saveImage(context: Context, image: ByteArray, title: String, desc: String, relativePath: String): AssetEntity? {
     val (width, height) =
         try {
           val bmp = BitmapFactory.decodeByteArray(image, 0, image.count())
@@ -388,6 +388,7 @@ object AndroidQDBUtils : IDBUtils {
       put(MediaStore.Images.ImageColumns.WIDTH, width)
       put(MediaStore.Images.ImageColumns.HEIGHT, height)
     }
+    if (relativePath != null) values.put(MediaStore.Images.ImageColumns.RELATIVE_PATH, relativePath)
 
     val contentUri = cr.insert(uri, values) ?: return null
     val outputStream = cr.openOutputStream(contentUri)
@@ -404,7 +405,7 @@ object AndroidQDBUtils : IDBUtils {
     return getAssetEntity(context, id.toString())
   }
 
-  override fun saveImage(context: Context, path: String, title: String, desc: String): AssetEntity? {
+  override fun saveImage(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
     val inputStream = FileInputStream(path)
@@ -436,6 +437,7 @@ object AndroidQDBUtils : IDBUtils {
       put(MediaStore.Images.ImageColumns.WIDTH, width)
       put(MediaStore.Images.ImageColumns.HEIGHT, height)
     }
+    if (relativePath != null) values.put(MediaStore.Images.ImageColumns.RELATIVE_PATH, relativePath)
 
     val contentUri = cr.insert(uri, values) ?: return null
     val outputStream = cr.openOutputStream(contentUri)
@@ -633,7 +635,7 @@ object AndroidQDBUtils : IDBUtils {
     }
   }
 
-  override fun saveVideo(context: Context, path: String, title: String, desc: String): AssetEntity? {
+  override fun saveVideo(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
     val inputStream = FileInputStream(path)
@@ -659,6 +661,7 @@ object AndroidQDBUtils : IDBUtils {
       put(MediaStore.Video.VideoColumns.WIDTH, info.width)
       put(MediaStore.Video.VideoColumns.HEIGHT, info.height)
     }
+    if (relativePath != null) values.put(MediaStore.Video.VideoColumns.RELATIVE_PATH, relativePath)
 
     val contentUri = cr.insert(uri, values) ?: return null
     val outputStream = cr.openOutputStream(contentUri)

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/AndroidQDBUtils.kt
@@ -371,7 +371,14 @@ object AndroidQDBUtils : IDBUtils {
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
 
-    val typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
+    var typeFromStream: String;
+    if (title.contains(".")){
+      //title contains file extension, form mimeType from it
+      typeFromStream = "image/${File(title).extension}"
+    } else {
+      typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
+              ?: "image/${File(title).extension}"
+    }
 
     val uri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
 

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/DBUtils.kt
@@ -336,7 +336,7 @@ object DBUtils : IDBUtils {
       typeFromStream = "image/${File(title).extension}"
     } else {
       typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
-              ?: "image/${File(title).extension}"
+              ?: "image/*"
     }
 
 

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/DBUtils.kt
@@ -297,7 +297,7 @@ object DBUtils : IDBUtils {
     cacheContainer.clearCache()
   }
 
-  override fun saveImage(context: Context, image: ByteArray, title: String, desc: String): AssetEntity? {
+  override fun saveImage(context: Context, image: ByteArray, title: String, desc: String, relativePath: String): AssetEntity? {
     val cr = context.contentResolver
     var inputStream = ByteArrayInputStream(image)
 
@@ -374,7 +374,7 @@ object DBUtils : IDBUtils {
     return getAssetEntity(context, id.toString())
   }
 
-  override fun saveImage(context: Context, path: String, title: String, desc: String): AssetEntity? {
+  override fun saveImage(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     val inputStream = FileInputStream(path)
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000
@@ -654,7 +654,7 @@ object DBUtils : IDBUtils {
     }
   }
 
-  override fun saveVideo(context: Context, path: String, title: String, desc: String): AssetEntity? {
+  override fun saveVideo(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity? {
     val inputStream = FileInputStream(path)
     val cr = context.contentResolver
     val timestamp = System.currentTimeMillis() / 1000

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/DBUtils.kt
@@ -330,8 +330,15 @@ object DBUtils : IDBUtils {
     val timestamp = System.currentTimeMillis() / 1000
     refreshInputStream()
 
-    val typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
-        ?: "image/${File(title).extension}"
+    var typeFromStream: String;
+    if (title.contains(".")){
+      //title contains file extension, form mimeType from it
+      typeFromStream = "image/${File(title).extension}"
+    } else {
+      typeFromStream = URLConnection.guessContentTypeFromStream(inputStream)
+              ?: "image/${File(title).extension}"
+    }
+
 
     val values = ContentValues().apply {
       put(MediaStore.Files.FileColumns.MEDIA_TYPE, MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE)

--- a/android/src/main/kotlin/top/kikt/imagescanner/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/core/utils/IDBUtils.kt
@@ -149,11 +149,11 @@ interface IDBUtils {
     return assetEntity.getUri()
   }
 
-  fun saveImage(context: Context, image: ByteArray, title: String, desc: String): AssetEntity?
+  fun saveImage(context: Context, image: ByteArray, title: String, desc: String, relativePath: String): AssetEntity?
 
-  fun saveImage(context: Context, path: String, title: String, desc: String): AssetEntity?
+  fun saveImage(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity?
 
-  fun saveVideo(context: Context, path: String, title: String, desc: String): AssetEntity?
+  fun saveVideo(context: Context, path: String, title: String, desc: String, relativePath: String): AssetEntity?
 
   fun exists(context: Context, id: String): Boolean {
     val columns = arrayOf(_ID)

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -25,6 +25,7 @@ class Editor {
   /// in Android is Picture.
   /// On Android 28 or lower, if the file is located in the external storage, it's path will be used in the MediaStore.
   /// On Android 29 or above, you can use [relativePath] to specify a RELATIVE_PATH used in the MediaStore.
+  /// The mimeType will either be formed from the title if you pass one, or guessed by the system, which does not always work.
   Future<AssetEntity?> saveImage(
     Uint8List data, {
     String? title,

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -48,8 +48,12 @@ class Editor {
     String? desc,
     String? relativePath,
   }) async {
-    return _plugin.saveImageWithPath(path,
-        title: title, desc: desc, relativePath: relativePath);
+    return _plugin.saveImageWithPath(
+      path,
+      title: title,
+      desc: desc,
+      relativePath: relativePath,
+    );
   }
 
   /// Save video to gallery.

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -23,36 +23,48 @@ class Editor {
   ///
   /// in iOS is Recent.
   /// in Android is Picture.
+  /// On Android 28 or lower, if the file is located in the external storage, it's path will be used in the MediaStore.
+  /// On Android 29 or above, you can use [relativePath] to specify a RELATIVE_PATH used in the MediaStore.
   Future<AssetEntity?> saveImage(
     Uint8List data, {
     String? title,
     String? desc,
+    String? relativePath,
   }) async {
-    return _plugin.saveImage(data, title: title, desc: desc);
+    return _plugin.saveImage(data,
+        title: title, desc: desc, relativePath: relativePath);
   }
 
   /// Save image to gallery.
   ///
   /// in iOS is Recent.
-  /// in Android is picture directory .(in android 28 or lower, If the path at the external storage, It will use the path.)
+  /// in Android is picture directory.
+  /// On Android 28 or lower, if the file is located in the external storage, it's path will be used in the MediaStore.
+  /// On Android 29 or above, you can use [relativePath] to specify a RELATIVE_PATH used in the MediaStore.
   Future<AssetEntity?> saveImageWithPath(
     String path, {
     String? title,
     String? desc,
+    String? relativePath,
   }) async {
-    return _plugin.saveImageWithPath(path, title: title, desc: desc);
+    return _plugin.saveImageWithPath(path,
+        title: title, desc: desc, relativePath: relativePath);
   }
 
   /// Save video to gallery.
   ///
   /// in iOS is Recent.
-  /// in Android is video directory .(in android 28 or lower, If the path at the external storage, It will use the path.)
+  /// in Android is video directory.
+  /// On Android 28 or lower, if the file is located in the external storage, it's path will be used in the MediaStore.
+  /// On Android 29 or above, you can use [relativePath] to specify a RELATIVE_PATH used in the MediaStore.
   Future<AssetEntity?> saveVideo(
     File file, {
     String? title,
     String? desc,
+    String? relativePath,
   }) async {
-    return _plugin.saveVideo(file, title: title, desc: desc);
+    return _plugin.saveVideo(file,
+        title: title, desc: desc, relativePath: relativePath);
   }
 
   /// Copy asset to another gallery.

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -176,6 +176,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     Uint8List data, {
     String? title,
     String? desc,
+    String? relativePath,
   }) async {
     title ??= 'image_${DateTime.now().millisecondsSinceEpoch / 1000}';
 
@@ -185,6 +186,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
         'image': data,
         'title': title,
         'desc': desc ?? '',
+        'relativePath': relativePath,
       },
     );
 
@@ -195,6 +197,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     String path, {
     String? title,
     String? desc,
+    String? relativePath,
   }) async {
     final file = File(path);
     if (!file.existsSync()) {
@@ -210,6 +213,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
         'path': path,
         'title': title,
         'desc': desc ?? '',
+        'relativePath': relativePath,
       },
     );
 
@@ -220,6 +224,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     File file, {
     String? title,
     String? desc,
+    String? relativePath,
   }) async {
     if (!file.existsSync()) {
       assert(file.existsSync(), 'file must exists');
@@ -231,6 +236,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
         'path': file.absolute.path,
         'title': title,
         'desc': desc ?? '',
+        'relativePath': relativePath,
       },
     );
     return ConvertUtils.convertToAsset(result);
@@ -252,6 +258,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
           'getLatLngAndroidQ',
           {'id': assetEntity.id},
         );
+
         /// 将返回的数据传入map
         return LatLng(latitude: map?['lat'], longitude: map?['lng']);
       }


### PR DESCRIPTION
On Android, currently saving a file to a custom folder is only possible on Android 28 or below. This PR allows saving to a custom folder on Android 29 or above aswell by using the RELATIVE_PATH field of the MediaStore. Example:
`await PhotoManager.editor.saveImageWithPath(file.path, relativePath: "DCIM/MyApp");`

This solves #428.