### PR TITLE
Fix thumb option with size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 - [CHANGELOG](#changelog)
+  - [1.1.1](#111)
   - [1.1.0](#110)
   - [1.0.6](#106)
   - [1.0.4](#104)
@@ -51,6 +52,10 @@
   - [0.0.3 fix bug](#003-fix-bug)
   - [0.0.2 update readme](#002-update-readme)
   - [0.0.1](#001)
+
+## 1.1.1
+
+- Fix: `thumbWithSize` of `AssetEntity`.
 
 ## 1.1.0
 

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -17,6 +17,7 @@ import 'package:provider/provider.dart';
 
 import 'copy_to_another_gallery_example.dart';
 import 'move_to_another_gallery_example.dart';
+import 'dart:ui' as ui;
 
 class GalleryContentListPage extends StatefulWidget {
   const GalleryContentListPage({
@@ -204,6 +205,11 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
               ElevatedButton(
                 child: Text("Test progress"),
                 onPressed: () => testProgressHandler(entity),
+              ),
+              ElevatedButton(
+                child: Text("Test thumb size"),
+                onPressed: () =>
+                    testThumbSize(entity, [500, 600, 700, 1000, 1500, 2000]),
               ),
             ],
           ),
@@ -395,7 +401,8 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
               height: 500,
               deliveryMode: DeliveryMode.opportunistic,
               resizeMode: ResizeMode.fast,
-              resizeContentMode: ResizeContentMode.fill,
+              resizeContentMode: ResizeContentMode.fit,
+              // resizeContentMode: ResizeContentMode.fill,
             ),
           ),
           builder: (BuildContext context, snapshot) {
@@ -403,7 +410,12 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
             if (snapshot.hasError) {
               return ErrorWidget(snapshot.error!);
             } else if (snapshot.hasData) {
-              w = Image.memory(snapshot.data!);
+              final data = snapshot.data!;
+              ui.decodeImageFromList(data, (result) {
+                print('result size: ${result.width}x${result.height}');
+                // for 4288x2848
+              });
+              w = Image.memory(data);
             } else {
               w = Center(
                 child: Container(
@@ -445,5 +457,22 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
       isOrigin: true,
     );
     print('file = $file');
+  }
+
+  testThumbSize(AssetEntity entity, List<int> list) async {
+    for (final size in list) {
+      final data = await entity.thumbDataWithOption(ThumbOption.ios(
+        width: size,
+        height: size,
+        resizeMode: ResizeMode.exact,
+      ));
+      if (data == null) {
+        return;
+      }
+      ui.decodeImageFromList(data, (result) {
+        print(
+            'size:$size length:${data.length}, size: ${result.width}x${result.height}');
+      });
+    }
   }
 }

--- a/lib/src/thumb_option.dart
+++ b/lib/src/thumb_option.dart
@@ -14,7 +14,7 @@ class ThumbOption {
     ThumbFormat format = ThumbFormat.jpeg,
     int quality = 95,
     DeliveryMode deliveryMode = DeliveryMode.opportunistic,
-    ResizeMode resizeMode = ResizeMode.none,
+    ResizeMode resizeMode = ResizeMode.fast,
     ResizeContentMode resizeContentMode = ResizeContentMode.fit,
   }) {
     return _IosThumbOption(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager
 description: You can scan photos and albums. Only api, not have ui. you can use the api to create your image picker. or use photo
-version: 1.1.0
+version: 1.1.1
 # author: caijinglong<cjl_spy@163.com>
 homepage: https://github.com/CaiJingLong/flutter_photo_manager
 


### PR DESCRIPTION
The issue: 
```dart
testThumbSize(AssetEntity entity, List<int> list) async {
    for (final size in list) {
      final data = await entity.thumbDataWithSize(
        size,
        size,
      );
      if (data == null) {
        return;
      }
      ui.decodeImageFromList(data, (result) {
        print(
            'size:$size length:${data.length}, size: ${result.width}x${result.height}');
      });
    }
  }
```

![image](https://user-images.githubusercontent.com/14145407/114257657-0a5eff80-99f4-11eb-93c1-0e9544af58b6.png)


The method will return error size thumb on iOS.

---

The pull request will fix it.