### PR TITLE
fetchFullSizeVideo will cause a loop and return file path before export session process done.

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -473,23 +473,24 @@
                       attributes:@{}
                            error:nil];
 
-  [path appendFormat:@"%@/%@", @".video", filename];
+  [path appendFormat:@"%@/%d_%@", @".video", (int)asset.modificationDate.timeIntervalSince1970 ,filename];
+  
   PHVideoRequestOptions *options = [PHVideoRequestOptions new];
+  options.version = PHVideoRequestOptionsVersionCurrent;
   if ([manager fileExistsAtPath:path]) {
     [[PMLogUtils sharedInstance]
         info:[NSString stringWithFormat:@"read cache from %@", path]];
     [handler reply:path];
     return;
   }
-
-
+    
   [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
   [options setProgressHandler:^(double progress, NSError *error, BOOL *stop,
-      NSDictionary *info) {
+                                NSDictionary *info) {
     if (progress == 1.0) {
-      [self fetchFullSizeVideo:asset handler:handler progressHandler:nil];
+      [self notifyProgress:progressHandler progress:progress state:PMProgressStateLoading];
     }
-
+    
     if (error) {
       [self notifyProgress:progressHandler progress:progress state:PMProgressStateFailed];
       [progressHandler deinit];
@@ -501,35 +502,36 @@
   }];
 
   [options setNetworkAccessAllowed:YES];
-
   [[PHImageManager defaultManager]
-      requestAVAssetForVideo:asset
-                     options:options
-               resultHandler:^(AVAsset *_Nullable asset,
-                   AVAudioMix *_Nullable audioMix,
-                   NSDictionary *_Nullable info) {
-                 BOOL downloadFinish = [PMManager isDownloadFinish:info];
-
-                 if (!downloadFinish) {
-                   return;
-                 }
-
-                 NSString *preset = AVAssetExportPresetHighestQuality;
-                 AVAssetExportSession *exportSession =
-                     [AVAssetExportSession exportSessionWithAsset:asset
-                                                       presetName:preset];
-                 if (exportSession) {
-                   exportSession.outputFileType = AVFileTypeMPEG4;
-                   exportSession.outputURL = [NSURL fileURLWithPath:path];
-                   [exportSession exportAsynchronouslyWithCompletionHandler:^{
-                     [handler reply:path];
-                   }];
-
-                   [self notifySuccess:progressHandler];
-                 } else {
-                   [handler reply:nil];
-                 }
-               }];
+   requestExportSessionForVideo:asset options:options exportPreset:AVAssetExportPresetHighestQuality resultHandler:^(AVAssetExportSession *_Nullable exportSession, NSDictionary *_Nullable info) {
+    BOOL downloadFinish = [PMManager isDownloadFinish:info];
+    
+    if (!downloadFinish) {
+      NSLog(@"Asset download fail: %@");
+      [handler reply:nil];
+      return;
+    }
+    
+    if (exportSession) {
+      exportSession.shouldOptimizeForNetworkUse = YES;
+      exportSession.outputFileType = AVFileTypeMPEG4;
+      exportSession.outputURL = [NSURL fileURLWithPath:path];
+      [exportSession exportAsynchronouslyWithCompletionHandler:^{
+        if ([exportSession status] == AVAssetExportSessionStatusCompleted) {
+          [handler reply:path];
+        } else if ([exportSession status] == AVAssetExportSessionStatusFailed) {
+          NSLog(@"Export session failed: %@", exportSession.error);
+          [handler reply:nil];
+        } else if ([exportSession status] == AVAssetExportSessionStatusCancelled) {
+          NSLog(@"Export session cancelled: %@", exportSession.error);
+          [handler reply:nil];
+        }
+      }];
+      [self notifySuccess:progressHandler];
+    } else {
+      [handler reply:nil];
+    }
+  }];
 }
 
 - (NSString *)makeAssetOutputPath:(PHAsset *)asset isOrigin:(Boolean)isOrigin {


### PR DESCRIPTION
1. Fix fetchFullSizeVideo flow logic. Avoid keeping call fetchFullSizeVideo when progress is 1.0. This operation cause a loop and return ile path before export session process done. 

2. Change requestAVAssetForVideo to requestExportSessionForVideo. Avoid iCloud file export failure. Ref: https://github.com/banchichen/TZImagePickerController/issues/1073 

3. Add modification date as file name prefix. Avoid to get the cache file if user modified the video.