### PR TITLE
Add request permissions result listener when activity re-attached

### DIFF
--- a/android/src/main/kotlin/top/kikt/imagescanner/ImageScannerPlugin.kt
+++ b/android/src/main/kotlin/top/kikt/imagescanner/ImageScannerPlugin.kt
@@ -5,7 +5,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener
 import top.kikt.imagescanner.core.PhotoManagerPlugin
 import top.kikt.imagescanner.permission.PermissionsUtils
@@ -14,21 +13,12 @@ class ImageScannerPlugin : FlutterPlugin, ActivityAware {
   private var plugin: PhotoManagerPlugin? = null
   private val permissionsUtils = PermissionsUtils()
 
-  var binding: ActivityPluginBinding? = null
+  private var binding: ActivityPluginBinding? = null
 
   companion object {
     fun register(plugin: PhotoManagerPlugin, messenger: BinaryMessenger) {
       val newChannel = MethodChannel(messenger, "top.kikt/photo_manager")
       newChannel.setMethodCallHandler(plugin)
-    }
-
-    @JvmStatic
-    fun registerWith(registrar: Registrar): Unit {
-      val permissionsUtils = PermissionsUtils()
-      registrar.addRequestPermissionsResultListener(createAddRequestPermissionsResultListener(permissionsUtils))
-      val plugin = PhotoManagerPlugin(registrar.context(), registrar.messenger(), registrar.activity(), permissionsUtils)
-      register(plugin, registrar.messenger())
-      registrar.addActivityResultListener(plugin.deleteManager)
     }
 
     fun createAddRequestPermissionsResultListener(permissionsUtils: PermissionsUtils): RequestPermissionsResultListener {
@@ -45,6 +35,7 @@ class ImageScannerPlugin : FlutterPlugin, ActivityAware {
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    plugin = null
   }
 
   override fun onDetachedFromActivity() {
@@ -53,22 +44,29 @@ class ImageScannerPlugin : FlutterPlugin, ActivityAware {
     }
   }
 
-  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-    this.binding = binding
-    plugin?.bindActivity(binding.activity)
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    activityAttached(binding)
   }
 
-  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    this.binding = binding
-    plugin?.bindActivity(binding.activity)
-    binding.addRequestPermissionsResultListener(createAddRequestPermissionsResultListener(permissionsUtils))
-      plugin?.let {
-        binding.addActivityResultListener(it.deleteManager)
-      }
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    activityAttached(binding)
   }
 
   override fun onDetachedFromActivityForConfigChanges() {
     plugin?.bindActivity(null)
+  }
+
+  private fun activityAttached(binding: ActivityPluginBinding) {
+    this.binding = binding
+    plugin?.bindActivity(binding.activity)
+    addRequestPermissionsResultListener(binding)
+  }
+
+  private fun addRequestPermissionsResultListener(binding: ActivityPluginBinding) {
+    binding.addRequestPermissionsResultListener(createAddRequestPermissionsResultListener(permissionsUtils))
+    plugin?.let {
+      binding.addActivityResultListener(it.deleteManager)
+    }
   }
 }
 


### PR DESCRIPTION
Fix #355 .

* Remove deprecated `registerWith`.
* Release plugin instance when detached from the engine.
* Extract the add listener's method.