### PR TITLE
Fix `AssetPathEntity.fromId`

### DIFF
--- a/lib/src/entity.dart
+++ b/lib/src/entity.dart
@@ -6,11 +6,16 @@ class AssetPathEntity {
   static Future<AssetPathEntity> fromId(
     String id, {
     FilterOptionGroup? filterOption,
+    RequestType type = RequestType.common,
+    int albumType = 1,
   }) async {
+    assert(albumType == 1 || Platform.isIOS || Platform.isMacOS);
     filterOption ??= FilterOptionGroup();
     final entity = AssetPathEntity()
       ..id = id
-      ..filterOption = filterOption;
+      ..filterOption = filterOption
+      ..typeInt = type.index
+      ..albumType = 1;
     await entity.refreshPathProperties();
     return entity;
   }


### PR DESCRIPTION
Continued from #360, fix #531 .

Some other properties still missing, but they are enough to create a `AssetPathEntity`.