### PR TITLE
Limit `AssetPathEntity` methods when the permission is not fully authorized

### DIFF
--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -181,8 +181,9 @@
 #endif
 }
 
-- (void) requestPermissionStatus:((int)) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
-    if (@available(iOS 14, *)) {
+- (void) requestPermissionStatus:(int) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
+#if __MAC_11_0
+    if (@available(macOS 11.0, *)) {
         [PHPhotoLibrary requestAuthorizationForAccessLevel:requestAccessLevel handler:^(PHAuthorizationStatus status) {
             completeHandler(status);
         }];
@@ -191,6 +192,11 @@
             completeHandler(status);
         }];
     }
+#else
+    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+        completeHandler(status);
+    }];
+#endif
 }
 
 -(void)presentLimited {

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -148,7 +148,7 @@
     }];
 }
 
-- (void) requestPermissionStatus:(int) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
+- (void) requestPermissionStatus:(PHAccessLevel) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
     [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
         completeHandler(status);
     }];
@@ -181,7 +181,7 @@
 #endif
 }
 
-- (void) requestPermissionStatus:(int) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
+- (void) requestPermissionStatus:(PHAccessLevel) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
     if (@available(iOS 14, *)) {
         [PHPhotoLibrary requestAuthorizationForAccessLevel:requestAccessLevel handler:^(PHAuthorizationStatus status) {
             completeHandler(status);

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -103,7 +103,8 @@
     }
 }
 
-- (void) requestPermissionStatus:(int) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
+- (void)requestPermissionStatus:(int)requestAccessLevel
+                completeHandler:(void (^)(PHAuthorizationStatus status))completeHandler {
     if (@available(iOS 14, *)) {
         [PHPhotoLibrary requestAuthorizationForAccessLevel:requestAccessLevel handler:^(PHAuthorizationStatus status) {
             completeHandler(status);
@@ -148,7 +149,8 @@
     }];
 }
 
-- (void) requestPermissionStatus:((int)) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
+- (void)requestPermissionStatus:(int)requestAccessLevel
+                completeHandler:(void (^)(PHAuthorizationStatus status))completeHandler {
     [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
         completeHandler(status);
     }];
@@ -164,7 +166,7 @@
 - (void) handlePermission:(PMManager *)manager handler:(ResultHandler*) handler requestAccessLevel:(int)requestAccessLevel {
     
 #if __MAC_11_0
-    
+
     if (@available(macOS 11.0, *)) {
         [PHPhotoLibrary requestAuthorizationForAccessLevel:requestAccessLevel handler:^(PHAuthorizationStatus status) {
             [self replyPermssionResult:handler status:status];
@@ -181,7 +183,8 @@
 #endif
 }
 
-- (void) requestPermissionStatus:(int) requestAccessLevel completeHandler:(void (^)(PHAuthorizationStatus status)) completeHandler {
+- (void)requestPermissionStatus:(int)requestAccessLevel
+                completeHandler:(void (^)(PHAuthorizationStatus status))completeHandler {
 #if __MAC_11_0
     if (@available(macOS 11.0, *)) {
         [PHPhotoLibrary requestAuthorizationForAccessLevel:requestAccessLevel handler:^(PHAuthorizationStatus status) {
@@ -281,7 +284,9 @@
         int requestType = [call.arguments[@"type"] intValue];
         PMFilterOptionGroup *option =
             [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
-        PMAssetPathEntity *pathEntity = [manager fetchPathProperties:id type:requestType filterOption:option];
+        PMAssetPathEntity *pathEntity = [manager fetchPathProperties:id
+                                                                type:requestType
+                                                        filterOption:option];
         if (option.containsModified) {
           [manager injectModifyToDate:pathEntity];
         }
@@ -507,7 +512,7 @@
   return handler;
 }
 
-- (void) createFolder:(FlutterMethodCall *) call manager:(PMManager *) manager handler:(ResultHandler *) handler {
+- (void)createFolder:(FlutterMethodCall *)call manager:(PMManager *)manager handler:(ResultHandler *)handler {
     NSString *name = call.arguments[@"name"];
     BOOL isRoot = [call.arguments[@"isRoot"] boolValue];
     NSString *parentId = call.arguments[@"folderId"];
@@ -521,7 +526,7 @@
     }];
 }
 
-- (void) createAlbum:(FlutterMethodCall *) call manager:(PMManager *) manager handler:(ResultHandler *) handler {
+- (void) createAlbum:(FlutterMethodCall *)call manager:(PMManager *)manager handler:(ResultHandler *)handler {
     NSString *name = call.arguments[@"name"];
     BOOL isRoot = [call.arguments[@"isRoot"] boolValue];
     NSString *parentId = call.arguments[@"folderId"];


### PR DESCRIPTION
This pull request intends to fix the root cause of the #531 , that the methods related to the `AssetPathEntity` is not working when the permission is limited, not fully authorized.