### PR TITLE
iCloud photos fetch fix

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -366,10 +366,6 @@
     [requestOptions setNetworkAccessAllowed:YES];
     [requestOptions setProgressHandler:^(double progress, NSError *error, BOOL *stop,
                                          NSDictionary *info) {
-        if (progress == 1.0) {
-            [self fetchThumb:asset option:option resultHandler:handler progressHandler:nil];
-        }
-        
         if (error) {
             [self notifyProgress:progressHandler progress:progress state:PMProgressStateFailed];
             [progressHandler deinit];
@@ -590,10 +586,6 @@
     [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     [options setProgressHandler:^(double progress, NSError *error, BOOL *stop,
                                   NSDictionary *info) {
-        if (progress == 1.0) {
-            [self fetchFullSizeImageFile:asset resultHandler:handler progressHandler:nil];
-        }
-        
         if (error) {
             [self notifyProgress:progressHandler progress:progress state:PMProgressStateFailed];
             [progressHandler deinit];


### PR DESCRIPTION
#558 removed the same calls for video
Seems like those calls lock thread and hang photo loading

Issues:
https://github.com/CaiJingLong/flutter_photo_manager/issues/411
https://github.com/CaiJingLong/flutter_photo_manager/issues/377
https://github.com/CaiJingLong/flutter_photo_manager/issues/308
https://github.com/CaiJingLong/flutter_photo_manager/issues/420