### PR TITLE
Fix list all album on iOS

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -82,38 +82,23 @@
                                                             fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
                                                             subtype:PHAssetCollectionSubtypeAlbumRegular
                                                             options:fetchCollectionOptions];
-    
     [self logCollections:smartAlbumResult option:assetOptions];
-    
     [self injectAssetPathIntoArray:array
                             result:smartAlbumResult
                            options:assetOptions
                             hasAll:hasAll
-                containsEmptyAlbum:option.containsEmptyAlbum
-     ];
-    
-    /*
-    PHFetchResult<PHCollection *> *topLevelResult = [PHAssetCollection
-                                                     fetchTopLevelUserCollectionsWithOptions:fetchCollectionOptions];
-    
-    [self logCollections:topLevelResult option:assetOptions];
-    
+                containsEmptyAlbum:option.containsEmptyAlbum];
+  
+    PHFetchResult<PHAssetCollection *> *albumResult = [PHAssetCollection
+                                                                fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
+                                                                subtype:PHAssetCollectionSubtypeAny
+                                                                options:fetchCollectionOptions];
+    [self logCollections:albumResult option:assetOptions];
     [self injectAssetPathIntoArray:array
-                            result:topLevelResult
+                            result:albumResult
                            options:assetOptions
                             hasAll:hasAll
-                containsEmptyAlbum:option.containsEmptyAlbum
-     ];
-     */
-
-    PHFetchResult *userAlbumsResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary options:fetchCollectionOptions];
-    [self logCollections:userAlbumsResult option:assetOptions];
-    [self injectAssetPathIntoArray:array
-                            result:userAlbumsResult
-                           options:assetOptions
-                            hasAll:hasAll
-                containsEmptyAlbum:option.containsEmptyAlbum
-     ];
+                containsEmptyAlbum:option.containsEmptyAlbum];
 
     return array;
 }

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -92,6 +92,7 @@
                 containsEmptyAlbum:option.containsEmptyAlbum
      ];
     
+    /*
     PHFetchResult<PHCollection *> *topLevelResult = [PHAssetCollection
                                                      fetchTopLevelUserCollectionsWithOptions:fetchCollectionOptions];
     
@@ -103,7 +104,17 @@
                             hasAll:hasAll
                 containsEmptyAlbum:option.containsEmptyAlbum
      ];
-    
+     */
+
+    PHFetchResult *userAlbumsResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary options:fetchCollectionOptions];
+    [self logCollections:userAlbumsResult option:assetOptions];
+    [self injectAssetPathIntoArray:array
+                            result:userAlbumsResult
+                           options:assetOptions
+                            hasAll:hasAll
+                containsEmptyAlbum:option.containsEmptyAlbum
+     ];
+
     return array;
 }
 


### PR DESCRIPTION
1. Fix sync photos between mac and ios, but PhotoManager.getAssetPathList can't fetch "from my mac" problem.
2. Fix user add a album in a new folder, but PhotoManager.getAssetPathList can't fetch this albem problem.

- 修正使用者從mac同步至ios後，ios會產生一個from my mac及相簿，但PhotoManager.getAssetPathList無法取得該相簿問題。
- ios照片內新增資料夾及相簿，但PhotoManager.getAssetPathList無法取得該資料夾內相簿問題。