### PR TITLE
iOS photo sort problem.

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -222,7 +222,7 @@
     BOOL videoNeedTitle = filterOption.videoOption.needTitle;
     
     for (NSUInteger i = startIndex; i <= endIndex; i++) {
-        PHAsset *asset = assetArray[i];
+        PHAsset *asset = assetArray[count - 1 - i];
         BOOL needTitle = NO;
         if ([asset isVideo]) {
             needTitle = videoNeedTitle;
@@ -268,7 +268,7 @@
     }
     
     for (NSUInteger i = startIndex; i <= endIndex; i++) {
-        PHAsset *asset = assetArray[i];
+        PHAsset *asset = assetArray[count - 1 - i];
         BOOL needTitle;
         if ([asset isVideo]) {
             needTitle = filterOption.videoOption.needTitle;
@@ -720,7 +720,7 @@
 
 - (PHFetchOptions *)getAssetOptions:(int)type filterOption:(PMFilterOptionGroup *)optionGroup {
     PHFetchOptions *options = [PHFetchOptions new];
-    options.sortDescriptors = [optionGroup sortCond];
+//    options.sortDescriptors = [optionGroup sortCond];
     
     NSMutableString *cond = [NSMutableString new];
     NSMutableArray *args = [NSMutableArray new];


### PR DESCRIPTION
在iOS里，这个玩意排序不对，在 PMManger.m 中的 `getAssetOptions` 方法里面，有个默认值
    PHFetchOptions *options = [PHFetchOptions new];
//    options.sortDescriptors = [optionGroup sortCond];

这样就相当于 默认加入了一个排序参数，这不河里。

因为在 `getAssetEntityListWithGalleryId` ， `getAssetEntityListWithRange` ，
调用ios的 PHAsset fetchAssetsInAssetCollection，返回的列表，就是相册的排序列表，只不过是从 0 - n
上述两个方法的改动 由 `assetArray[i]` 改为 `assetArray[count - 1 - i]`，从 n 获取到 0，就实现倒序了

Test: 

- 通过 air drop 传入一张日期比较久远的照片
- 然后可以用 example 来 和 系统相册 比较顺序

其他:
其他情况可能没有考虑周全，也可能会出现问题😑



