### PR TITLE
🔥 Apply more deprecations

### DIFF
--- a/lib/src/entity.dart
+++ b/lib/src/entity.dart
@@ -127,9 +127,6 @@ class AssetPathEntity {
     );
   }
 
-  /// All of asset.
-  ///
-  /// It is recommended to use [getAssetListPaged] or [getAssetListRange].
   @Deprecated(
     'Use getAssetListPaged or getAssetListRange for better performance. '
     'This feature was deprecated after v1.4.0.',

--- a/lib/src/entity.dart
+++ b/lib/src/entity.dart
@@ -42,9 +42,6 @@ class AssetPathEntity {
   /// In android: always 1.
   late int albumType;
 
-  /// path asset type.
-  late RequestType _type;
-
   late FilterOptionGroup filterOption;
 
   /// The modification time of the latest asset contained in an album.
@@ -55,6 +52,7 @@ class AssetPathEntity {
   /// The value used internally by the user.
   /// Used to indicate the value that should be available inside the path.
   RequestType get type => _type;
+  late RequestType _type;
 
   set type(RequestType type) {
     _type = type;
@@ -64,7 +62,7 @@ class AssetPathEntity {
   /// Users should not edit this value.
   ///
   /// This is a field used internally by the library.
-  int get typeInt => type.value;
+  int get typeInt => _type.value;
 
   /// Users should not edit this value.
   ///
@@ -105,22 +103,16 @@ class AssetPathEntity {
     }
   }
 
-  /// the image entity list with pagination
-  ///
-  /// Doesn't support AssetPathEntity with only(Video/Image) flag.
-  /// Throws UnsupportedError
+  /// Entity list with pagination support.
   ///
   /// [page] is starting 0.
-  ///
   /// [pageSize] is item count of page.
-  ///
   Future<List<AssetEntity>> getAssetListPaged(int page, int pageSize) {
     assert(this.albumType == 1, "Just album type can get asset.");
     assert(pageSize > 0, "The pageSize must better than 0.");
     return PhotoManager._getAssetListPaged(this, page, pageSize);
   }
 
-  /// The [start] and [end] like the [String.substring].
   Future<List<AssetEntity>> getAssetListRange({
     required int start,
     required int end,
@@ -135,15 +127,21 @@ class AssetPathEntity {
     );
   }
 
-  /// all of asset, It is recommended to use the latest api (pagination) [getAssetListPaged].
+  /// All of asset.
+  ///
+  /// It is recommended to use [getAssetListPaged] or [getAssetListRange].
+  @Deprecated(
+    'Use getAssetListPaged or getAssetListRange for better performance. '
+    'This feature was deprecated after v1.4.0.',
+  )
   Future<List<AssetEntity>> get assetList => getAssetListPaged(0, assetCount);
 
   /// In android, always return empty list.
   Future<List<AssetPathEntity>> getSubPathList() async {
-    if (!(Platform.isIOS || Platform.isMacOS)) {
-      return [];
+    if (Platform.isIOS || Platform.isMacOS) {
+      return PhotoManager._getSubPath(this);
     }
-    return PhotoManager._getSubPath(this);
+    return <AssetPathEntity>[];
   }
 
   @override
@@ -318,14 +316,6 @@ class AssetEntity {
   /// If you need to see the loading status, look at the [loadFile].
   Future<File?> get originFile async =>
       PhotoManager._getFileWithId(id, isOrigin: true);
-
-  /// The asset's bytes.
-  ///
-  /// Use [originBytes]
-  ///
-  /// The property will be remove in 0.5.0.
-  @Deprecated("Use originBytes instead")
-  Future<Uint8List?> get fullData => PhotoManager._getFullDataWithId(id);
 
   /// The raw data stored in the device, the data may be large.
   ///

--- a/lib/src/filter/filter_options.dart
+++ b/lib/src/filter/filter_options.dart
@@ -51,18 +51,8 @@ class FilterOptionGroup {
   /// It's recommended to be true only if you really need it.
   bool containsPathModified = false;
 
-  @Deprecated('Please use createTimeCond.')
-  DateTimeCond get dateTimeCond => createTimeCond;
-
-  @Deprecated('Please use createTimeCond.')
-  set dateTimeCond(DateTimeCond dateTimeCond) {
-    createTimeCond = dateTimeCond;
-  }
-
   DateTimeCond createTimeCond = DateTimeCond.def();
-  DateTimeCond updateTimeCond = DateTimeCond.def().copyWith(
-    ignore: true,
-  );
+  DateTimeCond updateTimeCond = DateTimeCond.def().copyWith(ignore: true);
 
   FilterOption getOption(AssetType type) => _map[type]!;
 

--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -6,25 +6,28 @@ Plugin _plugin = Plugin();
 ///
 /// 这个类是整个库的核心类
 class PhotoManager {
-  /// in android WRITE_EXTERNAL_STORAGE  READ_EXTERNAL_STORAGE
-  ///
-  /// in ios request the photo permission
-  ///
-  /// Use [requestPermissionExtend] to instead;
-  // @Deprecated("Use requestPermissionExtend")
+  @Deprecated(
+    'Use requestPermissionExtend for support latest OS systems. '
+    'This feature was deprecated after v1.4.0.',
+  )
   static Future<bool> requestPermission() async {
     return (await requestPermissionExtend()).isAuth;
   }
 
-  /// Android: WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE, MEDIA_LOCATION
+  /// ### Android (AndroidManifest.xml)
+  ///  * WRITE_EXTERNAL_STORAGE
+  ///  * READ_EXTERNAL_STORAGE
+  ///  * ACCESS_MEDIA_LOCATION
   ///
-  /// iOS: NSPhotoLibraryUsageDescription of info.plist
+  /// ### iOS (Info.plist)
+  ///  * NSPhotoLibraryUsageDescription
   ///
-  /// macOS of Release.entitlements:
-  ///  - com.apple.security.assets.movies.read-write
-  ///  - com.apple.security.assets.music.read-write
+  /// ### macOS (Debug/Release.entitlements)
+  ///  * com.apple.security.assets.movies.read-write
+  ///  * com.apple.security.assets.music.read-write
   ///
-  /// Also see [PermissionState].
+  /// See also:
+  ///  * [PermissionState] which defines the state of the current application.
   static Future<PermissionState> requestPermissionExtend({
     PermisstionRequestOption requestOption = const PermisstionRequestOption(),
   }) async {
@@ -83,36 +86,20 @@ class PhotoManager {
     );
   }
 
-  /// Use [getAssetPathList] replaced.
-  @Deprecated("Use getAssetPathList replaced.")
-  static Future<List<AssetPathEntity>> getImageAsset() {
-    return getAssetPathList(type: RequestType.image);
-  }
-
-  /// Use [getAssetPathList] replaced.
-  @Deprecated("Use getAssetPathList replaced.")
-  static Future<List<AssetPathEntity>> getVideoAsset() {
-    return getAssetPathList(type: RequestType.video);
-  }
-
-  static Future<void> setLog(bool isLog) {
-    return _plugin.setLog(isLog);
-  }
+  static Future<void> setLog(bool isLog) => _plugin.setLog(isLog);
 
   /// Ignore permission checks at runtime, you can use third-party permission plugins to request permission. Default is false.
   ///
   /// For Android, a typical usage scenario may be to use it in Service, because Activity cannot be used in Service to detect runtime permissions, but it should be noted that deleting resources above android10 require activity to accept the result, so the delete system does not apply to this Attributes.
   ///
   /// For iOS, this feature is only added, please explore the specific application scenarios by yourself
-  static Future<void> setIgnorePermissionCheck(bool ignore) async {
-    await _plugin.ignorePermissionCheck(ignore);
+  static Future<void> setIgnorePermissionCheck(bool ignore) {
+    return _plugin.ignorePermissionCheck(ignore);
   }
 
   /// get video asset
   /// open setting page
-  static void openSetting() {
-    _plugin.openSetting();
-  }
+  static Future<void> openSetting() => _plugin.openSetting();
 
   static Future<List<AssetEntity>> _getAssetListPaged(
     AssetPathEntity entity,
@@ -219,10 +206,6 @@ class PhotoManager {
       return File(path);
     }
     return null;
-  }
-
-  static Future<Uint8List?> _getFullDataWithId(String id) async {
-    return _plugin.getOriginBytes(id);
   }
 
   static _getThumbDataWithOption(

--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -7,7 +7,7 @@ Plugin _plugin = Plugin();
 /// 这个类是整个库的核心类
 class PhotoManager {
   @Deprecated(
-    'Use requestPermissionExtend for support latest OS systems. '
+    'Use requestPermissionExtend for better compatibility. '
     'This feature was deprecated after v1.4.0.',
   )
   static Future<bool> requestPermission() async {
@@ -21,13 +21,15 @@ class PhotoManager {
   ///
   /// ### iOS (Info.plist)
   ///  * NSPhotoLibraryUsageDescription
+  ///  * NSPhotoLibraryAddUsageDescription
   ///
   /// ### macOS (Debug/Release.entitlements)
   ///  * com.apple.security.assets.movies.read-write
   ///  * com.apple.security.assets.music.read-write
   ///
   /// See also:
-  ///  * [PermissionState] which defines the state of the current application.
+  ///  * [PermissionState] which defines the permission state
+  ///    of the current application.
   static Future<PermissionState> requestPermissionExtend({
     PermisstionRequestOption requestOption = const PermisstionRequestOption(),
   }) async {


### PR DESCRIPTION
Removed APIs:
- `AssetEntity.fullData`
- `FilterOptionGroup.dateTimeCond`
- `PhotoManager.getImageAsset`
- `PhotoManager.getVideoAsset`
- `PhotoManager._getFullDataWithId`

Deprecated APIs:
- `AssetPathEntity.assetList`
- `PhotoManager.requestPermission`

Also improve some comments.